### PR TITLE
move key manager repo

### DIFF
--- a/deployment/kuadrant-openshift/key-manager/02-key-manager-deployment.yaml
+++ b/deployment/kuadrant-openshift/key-manager/02-key-manager-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: key-manager
-        image: ghcr.io/nerdalert/maas-key-manager:teams
+        image: ghcr.io/redhat-et/maas-key-manager:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
moved to:
https://github.com/orgs/redhat-et/packages/container/package/maas-key-manager


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the key-manager service to use a new container image (latest).
  * Deployment settings, including port 8080, health probes, resources, security context, and environment variables, remain unchanged.
  * No functional changes expected; existing APIs and integrations should continue to operate as before.
  * Startup and runtime behavior are consistent with previous versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->