### PR TITLE
Cleanup and add Prometheus/Grafana instructions for a fresh OpenShift cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ A comprehensive platform for **Models as a Service** with real-time policy manag
 ## 🚀 Quick Start
 
 - **For deploying Kuadrant on OpenShift, see → [deployment/kuadrant-openshift](deployment/kuadrant-openshift)**
-- **For manual deployment steps of Kuadrant on Vanilla Kube, see → [deployment/kuadrant-openshift](deployment/kuadrant)**
 - **For chargeback and token rate limiting see the [demo and deploy instructions](deployment/kuadrant-openshift/README-token-rate-limiting-openshift.md)**
 
 ### 1. Deploy Kuadrant Infrastructure (Dev on vanilla kubernetes)

--- a/deployment/kuadrant-openshift/README-observability.md
+++ b/deployment/kuadrant-openshift/README-observability.md
@@ -1,0 +1,209 @@
+# Grafana and Prometheus Setup for MAAS Observability
+
+Instructions for setting up Grafana and Prometheus monitoring for MaaS on OpenShift.
+
+## Overview
+
+This setup provides:
+- OpenShift user workload monitoring (Prometheus)
+- Grafana instance for monitoring dashboards  
+- Two Prometheus datasources (cluster and user workload monitoring)
+- Secure HTTPS access via OpenShift routes
+- Proper RBAC for accessing OpenShift monitoring stack
+
+## Installation Steps
+
+### Step 1: Install Grafana Operator and Enable User Workload Monitoring
+
+1. **Install Grafana Operator** (Manual via OpenShift Console):
+   - Log into the OpenShift Console
+   - Navigate to **Operators** → **OperatorHub** 
+   - Search for "Grafana Operator"
+   - Click **Install** and follow the installation wizard
+   - Install to **openshift-operators** namespace (default)
+
+2. **Run the automated install script**:
+   ```bash
+   ./install-prometheus-grafana.sh
+   ```
+   
+   This script will:
+   - Detect you're on OpenShift/ROSA
+   - Enable user workload monitoring
+   - Configure cluster monitoring appropriately
+
+### Step 2: Deploy Grafana and Observability Stack
+
+Deploy the complete observability stack:
+
+```bash
+# Apply complete observability stack (includes Grafana, datasources, and RBAC)
+kubectl apply -k kustomize/observability/
+
+# Apply routes for external access
+kubectl apply -f grafana-route.yaml
+```
+
+### Step 3: Verify Deployment
+
+Check that all components are running:
+
+```bash
+# Check user workload monitoring is enabled
+kubectl get pods -n openshift-user-workload-monitoring
+
+# Check Grafana namespace and pods
+kubectl get namespace maas-observability
+kubectl get pods -n maas-observability
+
+# Check Grafana service and routes
+kubectl get svc -n maas-observability
+kubectl get routes -n maas-observability
+
+# Check datasource status
+kubectl get grafanadatasources -n maas-observability
+```
+
+Expected output for routes:
+```
+NAME            HOST/PORT                                          PATH   SERVICES          PORT      TERMINATION   WILDCARD
+grafana-route   grafana.apps.maas2.octo-emerging.redhataicoe.com          grafana-service   grafana   edge          None
+```
+
+### Step 4: Access Grafana
+
+**URL**: https://grafana.apps.<your-cluster-domain>
+
+> Demo creds, change them :)
+
+**Login Credentials**:
+- Username: `root`
+- Password: `secret`
+
+## Configuration Details
+
+### Grafana Configuration
+
+The Grafana instance is configured with:
+- **Anonymous access**: Enabled for read-only access
+- **Admin user**: `root` with password `secret`
+- **TLS termination**: Edge termination for secure HTTPS
+- **Route**: Accessible via OpenShift router
+
+### Prometheus Datasources
+
+The setup includes two Prometheus datasources:
+
+1. **prometheus** (Cluster Monitoring):
+   - **URL**: `https://thanos-querier.openshift-monitoring.svc.cluster.local:9091`
+   - **Authentication**: Bearer token authentication
+   - **Metrics**: Cluster-wide monitoring metrics
+   - **Default**: No
+
+2. **user-workload-prometheus** (User Workload Monitoring):
+   - **URL**: `https://prometheus-user-workload.openshift-user-workload-monitoring.svc.cluster.local:9091`
+   - **Authentication**: Bearer token authentication
+   - **Metrics**: Application/user workload metrics
+   - **Default**: No
+
+### Network Configuration
+
+- **Namespace**: `maas-observability`
+- **Service**: `grafana-service` on port 3000
+- **Route**: HTTPS via OpenShift router
+- **Domain**: `apps.<your-cluster-domain>`
+
+## Monitoring Inference Services
+
+### Available Metrics
+
+With the user workload Prometheus datasource, you can monitor:
+- Inference service request rates
+- Response times and latency
+- Error rates
+- Token usage metrics (if Kuadrant token rate limiting is enabled)
+- Resource utilization (CPU, memory)
+
+### Creating Dashboards
+
+1. **Log into Grafana**
+2. **Import existing dashboards**:
+   - Navigate to **+** → **Import**
+   - Upload dashboard JSON file or paste JSON content
+   - When prompted for datasource mapping, select:
+     - `user-workload-prometheus` for application metrics
+     - `prometheus` for cluster metrics
+   - Click **Import**
+
+3. **Create custom dashboards**:
+   - Navigate to **+** → **Dashboard**
+   - Add panels with PromQL queries such as:
+   ```promql
+   # Request rate
+   rate(http_requests_total[5m])
+   
+   # Response time
+   histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))
+   
+   # Error rate
+   rate(http_requests_total{code!~"2.."}[5m])
+   
+   # Inference service metrics (if ServiceMonitors are configured)
+   rate(inference_requests_total[5m])
+   inference_request_duration_seconds
+   ```
+
+### Dashboard Import Issues
+
+**"DS_PROMETHEUS not found" Error**:
+- This occurs when importing dashboards that reference a datasource by a different name
+- **Solution**: During import, map the datasource variable to your actual datasource:
+  - `DS_PROMETHEUS` → `user-workload-prometheus` (for application metrics)
+  - `DS_PROMETHEUS` → `prometheus` (for cluster metrics)
+
+**Default Datasource**:
+- `user-workload-prometheus` is configured as the default datasource
+- New panels will automatically use this datasource unless specified otherwise
+
+## File Structure
+
+```
+deployment/kuadrant-openshift/
+├── install-prometheus-grafana.sh             # Automated install script for ROSA/OpenShift
+├── grafana-route.yaml                        # OpenShift route for Grafana external access
+├── kustomize/
+│   ├── observability/
+│   │   ├── grafana-deployment.yaml           # Complete Grafana deployment manifest
+│   │   └── kustomization.yaml                # Main observability kustomization
+│   └── prometheus/
+│       ├── grafana-rbac.yaml                 # Service account and basic RBAC
+│       ├── openshift-monitoring-rbac.yaml    # OpenShift cluster monitoring RBAC
+│       ├── prometheus-datasource.yaml        # Main cluster Prometheus datasource
+│       ├── user-workload-datasource.yaml     # User workload Prometheus datasource
+│       ├── kuadrant-servicemonitors.yaml     # ServiceMonitors for Kuadrant
+│       └── kustomization.yaml                # Prometheus components kustomization
+└── README-observability.md                   # This documentation
+```
+
+## Quick Start Summary
+
+For a new deployment, run these commands in order:
+
+```bash
+# 1. Install Grafana Operator via OpenShift Console
+# 2. Enable monitoring and deploy Grafana
+./install-prometheus-grafana.sh
+
+# 3. Deploy complete observability stack
+kubectl apply -k kustomize/observability/
+kubectl apply -f grafana-route.yaml
+
+# 4. Verify deployment
+kubectl get pods -n maas-observability
+kubectl get grafanadatasources -n maas-observability
+
+# 5. Access Grafana
+echo "https://grafana.apps.<your-cluster-domain>"
+echo "Username: root | Password: secret"
+```
+

--- a/deployment/kuadrant-openshift/README-token-rate-limiting-openshift.md
+++ b/deployment/kuadrant-openshift/README-token-rate-limiting-openshift.md
@@ -477,20 +477,14 @@ kubectl -n llm exec -it $GATEWAY_POD -c istio-proxy -- \
 
 ### 10. Access Grafana Dashboard via OpenShift Route
 
-Deploy the user workload monitoring data source and token usage dashboard:
-
-```bash
-# Deploy user workload monitoring data source for Grafana
-kubectl apply -f kustomize/prometheus/user-workload-datasource.yaml
-
-# Import token usage dashboard (requires Grafana UI or API)
-# Dashboard JSON available at: kustomize/prometheus/token-dashboard-import.json
+See [README-observability.md](./README-observability.md) for deploying observability.
 
 # Verify data source is created
-kubectl get grafanadatasource -n llm-d-observability
+kubectl get grafanadatasource -n maas-observability
 ```
 
-Access Grafana dashboard:
+Access the Demo Grafana dashboard:
+
 - **Grafana URL**: https://grafana-route-llm-d-observability.apps.summit-gpu.octo-emerging.redhataicoe.com
 - **Dashboard**: Import `kustomize/prometheus/token-dashboard-import.json` through Grafana UI
 

--- a/deployment/kuadrant-openshift/README.md
+++ b/deployment/kuadrant-openshift/README.md
@@ -432,20 +432,7 @@ done
 
 ### 9. Deploy Observability
 
-Deploy ServiceMonitors to integrate with OpenShift's existing Prometheus monitoring:
-
-```bash
-# Deploy ServiceMonitors for Kuadrant components (no additional Prometheus needed)
-kubectl apply -k kustomize/prometheus/
-
-# Verify ServiceMonitors are created
-kubectl get servicemonitor -n kuadrant-system
-
-# Access Grafana Dashboard via OpenShift Route
-# Grafana: https://grafana-route-llm-d-observability.apps.summit-gpu.octo-emerging.redhataicoe.com
-```
-
-**Note:** This deployment uses OpenShift's built-in user workload monitoring instead of deploying a separate Prometheus instance.
+See [README-observability.md](./README-observability.md) for deploying observability.
 
 ### Query the Limitador Scrape Endpoint
 

--- a/deployment/kuadrant-openshift/grafana-route.yaml
+++ b/deployment/kuadrant-openshift/grafana-route.yaml
@@ -1,0 +1,20 @@
+# OpenShift Route for Grafana Observability
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: grafana-route
+  namespace: maas-observability
+  labels:
+    app: grafana
+spec:
+  host: grafana.apps.maas2.octo-emerging.redhataicoe.com
+  port:
+    targetPort: grafana
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: grafana-service
+    weight: 100
+  wildcardPolicy: None

--- a/deployment/kuadrant-openshift/install-prometheus-grafana.sh
+++ b/deployment/kuadrant-openshift/install-prometheus-grafana.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# -*- indent-tabs-mode: nil; tab-width: 4; sh-indentation: 4; -*-
+
+set -euo pipefail
+
+### GLOBALS ###
+# Use central monitoring namespace by default (configurable via MONITORING_NAMESPACE env var)
+MONITORING_NAMESPACE="${MONITORING_NAMESPACE:-}"
+NAMESPACE_EXPLICITLY_SET=false
+ACTION="install"
+KUBERNETES_CONTEXT=""
+DEBUG=""
+CENTRAL_MODE=true
+
+### HELP & LOGGING ###
+print_help() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Install or uninstall Prometheus and Grafana stack for MAAS metrics collection.
+
+Options:
+  -n, --namespace NAME        Monitoring namespace (default: maas-observability for central mode)
+  -u, --uninstall             Uninstall Prometheus and Grafana stack
+  -d, --debug                 Add debug mode to the helm install
+  -g, --context               Supply a specific Kubernetes context
+  -i, --individual            Enable individual user monitoring mode (requires -n or MONITORING_NAMESPACE)
+  -h, --help                  Show this help and exit
+
+Environment Variables:
+  MONITORING_NAMESPACE        Override default monitoring namespace
+
+Examples:
+  $(basename "$0")                              # Install central monitoring in maas-observability (watches all namespaces)
+  $(basename "$0") -n monitoring                # Install central monitoring in 'monitoring' namespace
+  $(basename "$0") -u                           # Uninstall Prometheus/Grafana stack
+  $(basename "$0") -i -n my-monitoring          # Install individual monitoring in specified namespace
+  MONITORING_NAMESPACE=my-monitoring $(basename "$0") -i  # Individual mode via env var
+EOF
+}
+
+# ANSI colour helpers and functions
+COLOR_RESET=$'\e[0m'
+COLOR_GREEN=$'\e[32m'
+COLOR_YELLOW=$'\e[33m'
+COLOR_RED=$'\e[31m'
+COLOR_BLUE=$'\e[34m'
+
+log_info() {
+  echo "${COLOR_BLUE}ℹ️  $*${COLOR_RESET}"
+}
+
+log_success() {
+  echo "${COLOR_GREEN}✅ $*${COLOR_RESET}"
+}
+
+log_error() {
+  echo "${COLOR_RED}❌ $*${COLOR_RESET}" >&2
+}
+
+fail() { log_error "$*"; exit 1; }
+
+### UTILITIES ###
+check_cmd() {
+  command -v "$1" &>/dev/null || fail "Required command not found: $1"
+}
+
+check_dependencies() {
+  local required_cmds=(helm kubectl)
+  for cmd in "${required_cmds[@]}"; do
+    check_cmd "$cmd"
+  done
+}
+
+check_cluster_reachability() {
+  if kubectl cluster-info &> /dev/null; then
+    log_info "kubectl can reach to a running Kubernetes cluster."
+  else
+    fail "kubectl cannot reach any running Kubernetes cluster. The installer requires a running cluster"
+  fi
+}
+
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n|--namespace)                  MONITORING_NAMESPACE="$2"; NAMESPACE_EXPLICITLY_SET=true; shift 2 ;;
+      -u|--uninstall)                  ACTION="uninstall"; shift ;;
+      -d|--debug)                      DEBUG="--debug"; shift;;
+      -g|--context)                    KUBERNETES_CONTEXT="$2"; shift 2 ;;
+      -i|--individual)                 CENTRAL_MODE=false; shift ;;
+      -h|--help)                       print_help; exit 0 ;;
+      *)                               fail "Unknown option: $1" ;;
+    esac
+  done
+}
+
+setup_env() {
+  if [[ ! -z $KUBERNETES_CONTEXT ]]; then
+    if [[ ! -f $KUBERNETES_CONTEXT ]]; then
+      log_error "Error, the context file \"$KUBERNETES_CONTEXT\", passed via command-line option, does not exist!"
+      exit 1
+    fi
+    KCMD="kubectl --kubeconfig $KUBERNETES_CONTEXT"
+    HCMD="helm --kubeconfig $KUBERNETES_CONTEXT"
+  else
+    KCMD="kubectl"
+    HCMD="helm"
+  fi
+
+  # Set up monitoring namespace and labels based on mode
+  if [[ "$CENTRAL_MODE" == "true" ]]; then
+    # Central mode: use specified namespace or default to maas-observability
+    if [[ -z "$MONITORING_NAMESPACE" ]]; then
+      MONITORING_NAMESPACE="maas-observability"
+    fi
+    MONITORING_LABEL_KEY=""
+    MONITORING_LABEL_VALUE=""
+  else
+    # Individual mode: require explicit namespace
+    if [[ -z "$MONITORING_NAMESPACE" ]]; then
+      fail "Individual monitoring mode (-i) requires a namespace to be specified via -n flag or MONITORING_NAMESPACE environment variable"
+    fi
+    MONITORING_LABEL_KEY="monitoring-ns"
+    MONITORING_LABEL_VALUE="${MONITORING_NAMESPACE}"
+  fi
+}
+
+is_openshift() {
+  # Check for OpenShift-specific resources
+  if $KCMD get clusterversion &>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+check_servicemonitor_crd() {
+  log_info "🔍 Checking for ServiceMonitor CRD (monitoring.coreos.com)..."
+  if ! $KCMD get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
+    log_info "⚠️ ServiceMonitor CRD (monitoring.coreos.com) not found - will be installed with Prometheus stack"
+    return 1
+  fi
+
+  API_VERSION=$($KCMD get crd servicemonitors.monitoring.coreos.com -o jsonpath='{.spec.versions[?(@.served)].name}' 2>/dev/null || echo "")
+
+  if [[ -z "$API_VERSION" ]]; then
+    log_info "⚠️ Could not determine ServiceMonitor CRD API version"
+    return 1
+  fi
+
+  if [[ "$API_VERSION" == "v1" ]]; then
+    log_success "ServiceMonitor CRD (monitoring.coreos.com/v1) found - using existing installation"
+    return 0
+  else
+    log_info "⚠️ Found ServiceMonitor CRD but with unexpected API version: ${API_VERSION}"
+    return 1
+  fi
+}
+
+check_openshift_monitoring() {
+  if ! is_openshift; then
+    return 0
+  fi
+
+  log_info "🔍 Checking OpenShift user workload monitoring configuration..."
+
+  # Check if user workload monitoring is enabled
+  if $KCMD get configmap cluster-monitoring-config -n openshift-monitoring -o yaml 2>/dev/null | grep -q "enableUserWorkload: true"; then
+    log_success "✅ OpenShift user workload monitoring is properly configured"
+    return 0
+  fi
+
+  log_info "⚠️ OpenShift user workload monitoring is not enabled"
+  log_info "ℹ️ Enabling user workload monitoring allows metrics collection for the MAAS chart."
+
+  local monitoring_yaml=$(cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+)
+
+  # Prompt the user
+  log_info "📜 The following ConfigMap will be applied to enable user workload monitoring:"
+  echo "$monitoring_yaml"
+  read -p "Would you like to apply this ConfigMap to enable user workload monitoring? (y/N): " response
+  case "$response" in
+    [yY][eE][sS]|[yY])
+      log_info "🚀 Applying ConfigMap to enable user workload monitoring..."
+      echo "$monitoring_yaml" | oc create -f -
+      if [[ $? -eq 0 ]]; then
+        log_success "✅ OpenShift user workload monitoring enabled"
+        return 0
+      else
+        log_error "❌ Failed to apply ConfigMap. Metrics collection may not work."
+        return 1
+      fi
+      ;;
+    *)
+      log_info "⚠️ User chose not to enable user workload monitoring."
+      log_info "⚠️ Metrics collection may not work properly in OpenShift without user workload monitoring enabled."
+      return 1
+      ;;
+  esac
+}
+
+install_prometheus_grafana() {
+  log_info "🌱 Provisioning Prometheus operator…"
+
+  if ! $KCMD get namespace "${MONITORING_NAMESPACE}" &>/dev/null; then
+    log_info "📦 Creating monitoring namespace..."
+    $KCMD create namespace "${MONITORING_NAMESPACE}"
+  else
+    log_info "📦 Monitoring namespace already exists"
+  fi
+
+  if ! $HCMD repo list 2>/dev/null | grep -q "prometheus-community"; then
+    log_info "📚 Adding prometheus-community helm repo..."
+    $HCMD repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    $HCMD repo update
+  fi
+
+  # Check if release already exists using the same naming scheme
+  RELEASE_NAME="prometheus-${MONITORING_NAMESPACE}"
+
+  if $HCMD list -n "${MONITORING_NAMESPACE}" | grep -q "${RELEASE_NAME}"; then
+    log_info "⚠️ Prometheus stack already installed as '${RELEASE_NAME}' in ${MONITORING_NAMESPACE} namespace"
+    if [[ "$CENTRAL_MODE" == "true" ]]; then
+      log_info "ℹ️ To update existing installation to central mode, first uninstall with: $0 -u -n ${MONITORING_NAMESPACE}"
+    else
+      log_info "ℹ️ To update configuration, first uninstall with: $0 -u -n ${MONITORING_NAMESPACE}"
+    fi
+    return 0
+  fi
+
+  # Check if CRDs already exist (installed by another user)
+  if check_servicemonitor_crd; then
+    log_info "🔄 ServiceMonitor CRDs already exist - installing without CRDs to avoid conflicts"
+    CRD_INSTALL_FLAG="--skip-crds"
+  else
+    log_info "🆕 Installing Prometheus stack with CRDs"
+    CRD_INSTALL_FLAG=""
+  fi
+
+  log_info "🚀 Installing Prometheus stack in namespace ${MONITORING_NAMESPACE}..."
+
+  if [[ "$CENTRAL_MODE" == "true" ]]; then
+    # Central mode: Monitor all namespaces without label restrictions
+    cat <<EOF > /tmp/prometheus-values.yaml
+grafana:
+  adminPassword: admin
+  service:
+    type: ClusterIP
+prometheus:
+  service:
+    type: ClusterIP
+  prometheusSpec:
+    # Central monitoring: watch all ServiceMonitors and PodMonitors in all namespaces
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector: {}
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector: {}
+    podMonitorNamespaceSelector: {}
+    maximumStartupDurationSeconds: 300
+    # Higher resource limits for central monitoring
+    resources:
+      limits:
+        memory: 8Gi
+        cpu: 4000m
+      requests:
+        memory: 4Gi
+        cpu: 1000m
+EOF
+  else
+    # Individual mode: Monitor only user's labeled namespaces
+    cat <<EOF > /tmp/prometheus-values.yaml
+grafana:
+  adminPassword: admin
+  service:
+    type: ClusterIP
+prometheus:
+  service:
+    type: ClusterIP
+  prometheusSpec:
+    # Limit monitoring to user's namespaces for multi-tenancy
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    serviceMonitorNamespaceSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    podMonitorNamespaceSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    maximumStartupDurationSeconds: 300
+    # Resource limits for individual monitoring
+    resources:
+      limits:
+        memory: 4Gi
+        cpu: 2000m
+      requests:
+        memory: 2Gi
+        cpu: 500m
+EOF
+  fi
+
+  # Use unique release name based on namespace to avoid conflicts
+  RELEASE_NAME="prometheus-${MONITORING_NAMESPACE}"
+
+  $HCMD install "${RELEASE_NAME}" prometheus-community/kube-prometheus-stack \
+    --namespace "${MONITORING_NAMESPACE}" \
+    ${DEBUG} \
+    ${CRD_INSTALL_FLAG} \
+    -f /tmp/prometheus-values.yaml
+
+  rm -f /tmp/prometheus-values.yaml
+
+  log_info "⏳ Waiting for Prometheus stack pods to be ready..."
+  $KCMD wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus -n "${MONITORING_NAMESPACE}" --timeout=300s || true
+  $KCMD wait --for=condition=ready pod -l app.kubernetes.io/name=grafana -n "${MONITORING_NAMESPACE}" --timeout=300s || true
+
+  log_success "🚀 Prometheus and Grafana installed."
+
+  # Display access information
+  log_info "📊 Access Information:"
+  log_info "   Prometheus: kubectl port-forward -n ${MONITORING_NAMESPACE} svc/prometheus-kube-prometheus-prometheus 9090:9090"
+  log_info "   Grafana: kubectl port-forward -n ${MONITORING_NAMESPACE} svc/prometheus-grafana 3000:80"
+  log_info "   Grafana admin password: admin"
+  log_info ""
+  log_info "📋 Monitoring Configuration:"
+  if [[ "$CENTRAL_MODE" == "true" ]]; then
+    log_info "   🌐 Central monitoring: This Prometheus monitors ALL ServiceMonitors and PodMonitors in ALL namespaces"
+    log_info "   No namespace labeling is required - all metrics will be collected automatically"
+    log_info "   ⚠️  This mode should only be used by cluster administrators or in single-tenant environments"
+  else
+    log_info "   👤 Individual monitoring: This Prometheus monitors resources labeled with '${MONITORING_LABEL_KEY}: ${MONITORING_LABEL_VALUE}'"
+    log_info "   To enable monitoring for your deployments, add this label to your namespaces:"
+    log_info "   kubectl label namespace <namespace> ${MONITORING_LABEL_KEY}=${MONITORING_LABEL_VALUE}"
+  fi
+}
+
+install() {
+  if is_openshift; then
+    log_info "🔍 OpenShift detected - checking user workload monitoring..."
+    if ! check_openshift_monitoring; then
+      log_info "⚠️ Metrics collection may not work properly in OpenShift without user workload monitoring enabled."
+    fi
+    # No Prometheus installation needed if OpenShift monitoring is properly configured
+    log_info "ℹ️ Using OpenShift's built-in monitoring stack. No additional Prometheus installation needed."
+    log_success "🎉 OpenShift monitoring configuration complete."
+  else
+    log_info "🔍 Checking for existing ServiceMonitor CRD..."
+    if check_servicemonitor_crd; then
+      log_info "✅ ServiceMonitor CRD found. Installing namespace-scoped Prometheus stack..."
+    else
+      log_info "⚠️ ServiceMonitor CRD not found. Installing Prometheus stack with CRDs..."
+    fi
+    install_prometheus_grafana
+    log_success "🎉 Prometheus and Grafana installation complete."
+  fi
+}
+
+uninstall() {
+  log_info "🗑️ Uninstalling Prometheus and Grafana stack..."
+
+  # Use the same release naming scheme as install
+  RELEASE_NAME="prometheus-${MONITORING_NAMESPACE}"
+
+  if $HCMD list -n "${MONITORING_NAMESPACE}" | grep -q "${RELEASE_NAME}" 2>/dev/null; then
+    log_info "🗑️ Uninstalling Prometheus helm release '${RELEASE_NAME}'..."
+    $HCMD uninstall "${RELEASE_NAME}" --namespace "${MONITORING_NAMESPACE}" || true
+  fi
+
+  log_info "🗑️ Deleting monitoring namespace..."
+  $KCMD delete namespace "${MONITORING_NAMESPACE}" --ignore-not-found || true
+
+  # Check if we should delete the ServiceMonitor CRD (only if no other Prometheus installations exist)
+  if ! $KCMD get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
+    log_info "ℹ️ ServiceMonitor CRD not found (already deleted or never installed)"
+  else
+    log_info "ℹ️ ServiceMonitor CRD still exists (may be used by other monitoring installations)"
+    log_info "ℹ️ To manually delete: kubectl delete crd servicemonitors.monitoring.coreos.com"
+  fi
+
+  log_success "💀 Uninstallation complete"
+}
+
+main() {
+  parse_args "$@"
+  setup_env
+  check_dependencies
+  check_cluster_reachability
+
+  if [[ "$ACTION" == "install" ]]; then
+    install
+  elif [[ "$ACTION" == "uninstall" ]]; then
+    uninstall
+  else
+    fail "Unknown action: $ACTION"
+  fi
+}
+
+main "$@"

--- a/deployment/kuadrant-openshift/kustomize/observability/grafana-deployment.yaml
+++ b/deployment/kuadrant-openshift/kustomize/observability/grafana-deployment.yaml
@@ -1,0 +1,31 @@
+# Grafana Deployment for MAAS Observability
+# This manifest creates a complete Grafana setup for monitoring inference services
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maas-observability
+  labels:
+    name: maas-observability
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  namespace: maas-observability
+  labels:
+    app: grafana
+spec:
+  deployment:
+    spec:
+      replicas: 1
+  config:
+    auth:
+      disable_login_form: "false"
+    auth.anonymous:
+      enabled: "true"
+    log:
+      mode: console
+    security:
+      admin_password: secret
+      admin_user: root

--- a/deployment/kuadrant-openshift/kustomize/observability/kustomization.yaml
+++ b/deployment/kuadrant-openshift/kustomize/observability/kustomization.yaml
@@ -6,9 +6,11 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 
-namespace: llm-observability
+namespace: maas-observability
 
 resources:
+  # Grafana deployment
+  - grafana-deployment.yaml
   # Enhanced Prometheus
   - ../prometheus
 

--- a/deployment/kuadrant-openshift/kustomize/prometheus/grafana-instance.yaml
+++ b/deployment/kuadrant-openshift/kustomize/prometheus/grafana-instance.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maas-observability
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  namespace: maas-observability
+  labels:
+    app: grafana
+spec:
+  route:
+    spec:
+      host: grafana.apps.maas2.octo-emerging.redhataicoe.com
+      to:
+        kind: Service
+        name: grafana-service
+      port:
+        targetPort: grafana-http
+  deployment:
+    spec:
+      replicas: 1
+  config:
+    auth:
+      disable_login_form: "false"
+    auth.anonymous:
+      enabled: "true"
+    log:
+      mode: console
+    security:
+      admin_password: secret
+      admin_user: root

--- a/deployment/kuadrant-openshift/kustomize/prometheus/grafana-rbac.yaml
+++ b/deployment/kuadrant-openshift/kustomize/prometheus/grafana-rbac.yaml
@@ -1,0 +1,46 @@
+# RBAC for Grafana to access Prometheus
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-sa
+  namespace: maas-observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-prometheus-reader
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/metrics", "services", "endpoints", "pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics", "/federate", "/api/*"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-prometheus-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-prometheus-reader
+subjects:
+- kind: ServiceAccount
+  name: grafana-sa
+  namespace: maas-observability
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-sa-token
+  namespace: maas-observability
+  annotations:
+    kubernetes.io/service-account.name: grafana-sa
+type: kubernetes.io/service-account-token

--- a/deployment/kuadrant-openshift/kustomize/prometheus/grafana-token-dashboard-import.json
+++ b/deployment/kuadrant-openshift/kustomize/prometheus/grafana-token-dashboard-import.json
@@ -1,4 +1,13 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -18,13 +27,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": null,
   "links": [],
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -38,10 +47,6 @@
               {
                 "color": "blue",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 10000
               }
             ]
           },
@@ -87,7 +92,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -134,10 +139,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -229,7 +230,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -313,7 +314,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "token_usage_with_user_and_group",
           "legendFormat": "{{user}} ({{group}})",
@@ -327,12 +328,12 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
@@ -398,12 +399,12 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "palette-classic-by-name"
           },
           "custom": {
             "axisBorderShow": false,
@@ -489,7 +490,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -584,7 +585,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -596,7 +597,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "yellow",
@@ -650,7 +652,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -662,7 +664,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "yellow",
@@ -716,7 +719,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -728,7 +731,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -782,107 +786,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "^free$"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#06b6d4",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "^premium$"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#a855f7",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 47
-      },
-      "id": 9,
-      "options": {
-        "colorMode": "palette-classic",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.3.0",
-      "targets": [
-        {
-          "expr": "sum by (group) (token_usage_with_user_and_group{group=\"free\"}) * 0.005",
-          "instant": true,
-          "legendFormat": "free",
-          "refId": "A"
-        },
-        {
-          "expr": "sum by (group) (token_usage_with_user_and_group{group=\"premium\"}) * 0.008",
-          "instant": true,
-          "legendFormat": "premium",
-          "refId": "B"
-        }
-      ],
-      "title": "💳 Revenue by Tier (current)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -898,7 +802,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "yellow",
@@ -1001,8 +906,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 24,
+        "x": 0,
         "y": 47
       },
       "id": 12,
@@ -1045,208 +950,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Revenue Rate ($/hour)",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 30,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 55
-      },
-      "id": 18,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max",
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.3.0",
-      "targets": [
-        {
-          "expr": "sum(rate(token_usage_with_user_and_group{group=\"free\"}[1h]) * 3600 * 0.005) + sum(rate(token_usage_with_user_and_group{group=\"premium\"}[1h]) * 3600 * 0.008)",
-          "legendFormat": "Total Revenue Rate",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(token_usage_with_user_and_group{group=\"free\"}[1h]) * 3600 * 0.005)",
-          "legendFormat": "Free Tier Revenue Rate",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "expr": "sum(rate(token_usage_with_user_and_group{group=\"premium\"}[1h]) * 3600 * 0.008)",
-          "legendFormat": "Premium Tier Revenue Rate",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "⚡ Real-Time Revenue Velocity (Hourly Rate Trends)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Cost per User ($)",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 25,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 63
-      },
-      "id": 19,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.3.0",
-      "targets": [
-        {
-          "expr": "sum by (user) ((token_usage_with_user_and_group{group=\"free\"} * 0.005) or (token_usage_with_user_and_group{group=\"premium\"} * 0.008))",
-          "legendFormat": "{{user}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "📊 Individual Customer Value Over Time",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1255,7 +959,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1317,7 +1022,7 @@
         "h": 11,
         "w": 6,
         "x": 0,
-        "y": 71
+        "y": 55
       },
       "id": 3,
       "options": {
@@ -1352,7 +1057,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "1e33abde-3300-4ef2-9a35-5a0caafea5df"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1368,7 +1073,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-green"
+                "color": "dark-green",
+                "value": null
               }
             ]
           },
@@ -1435,7 +1141,7 @@
         "h": 11,
         "w": 18,
         "x": 6,
-        "y": 71
+        "y": 55
       },
       "id": 7,
       "options": {
@@ -1476,13 +1182,14 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "MaaS - User Token Usage",
-  "uid": "llm-tokens-clean",
-  "version": 4,
+  "uid": null,
+  "version": 1,
   "weekStart": ""
 }
+

--- a/deployment/kuadrant-openshift/kustomize/prometheus/kustomization.yaml
+++ b/deployment/kuadrant-openshift/kustomize/prometheus/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 
 resources:
   - kuadrant-servicemonitors.yaml
+  - grafana-rbac.yaml
+  - openshift-monitoring-rbac.yaml
+  - prometheus-datasource.yaml
+  - user-workload-datasource.yaml
 
 labels:
   - pairs:

--- a/deployment/kuadrant-openshift/kustomize/prometheus/openshift-monitoring-rbac.yaml
+++ b/deployment/kuadrant-openshift/kustomize/prometheus/openshift-monitoring-rbac.yaml
@@ -1,0 +1,27 @@
+# OpenShift Cluster Monitoring RBAC for Grafana
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: grafana-sa
+  namespace: maas-observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-monitoring-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring-rules-view
+subjects:
+- kind: ServiceAccount
+  name: grafana-sa
+  namespace: maas-observability

--- a/deployment/kuadrant-openshift/kustomize/prometheus/prometheus-datasource.yaml
+++ b/deployment/kuadrant-openshift/kustomize/prometheus/prometheus-datasource.yaml
@@ -1,24 +1,24 @@
-# User Workload Monitoring Prometheus Data Source for Token Usage Metrics
+# Simplified Main Prometheus Data Source
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
-  name: user-workload-prometheus
+  name: prometheus-main
   namespace: maas-observability
 spec:
   datasource:
     access: proxy
     editable: true
-    isDefault: true
+    isDefault: false
     jsonData:
       httpHeaderName1: Authorization
       timeInterval: 5s
       tlsSkipVerify: true
-    name: user-workload-prometheus
+    name: prometheus-main
     secureJsonData:
       httpHeaderValue1: Bearer ${token}
     type: prometheus
-    url: https://prometheus-user-workload.openshift-user-workload-monitoring.svc.cluster.local:9091
+    url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
   instanceSelector:
     matchLabels:
       app: grafana

--- a/deployment/model_serving/obc-rgw.yaml
+++ b/deployment/model_serving/obc-rgw.yaml
@@ -1,7 +1,0 @@
-apiVersion: objectbucket.io/v1alpha1
-kind: ObjectBucketClaim
-metadata:
-  name: models
-spec:
-  generateBucketName: models
-  storageClassName: ocs-storagecluster-ceph-rgw


### PR DESCRIPTION
- Adds user datasource, RBAC, Grafana sa, etc
- Installer script included borrowed from llm-d & @sallyom to setup cluster-monitoring-config Configmap in openshift-monitoring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a comprehensive Grafana/Prometheus observability setup for OpenShift, including installer tooling, RBAC, datasources, route exposure, and an updated, parameterized dashboard.
  - Standardized observability namespace to maas-observability.

- Documentation
  - Added a dedicated observability guide with installation, access, and troubleshooting.
  - Streamlined deployment docs to reference the new observability guide.
  - Updated token rate limiting instructions and Grafana access guidance.
  - Removed outdated Quick Start bullets for OpenShift and Vanilla Kubernetes.

- Chores
  - Removed an obsolete object storage claim manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->