### PR TITLE
chore: renames k8s client

### DIFF
--- a/key-manager/internal/models/kserve.go
+++ b/key-manager/internal/models/kserve.go
@@ -12,13 +12,13 @@ import (
 
 // Manager handles model discovery and listing
 type Manager struct {
-	kuadrantClient dynamic.Interface
+	k8sClient dynamic.Interface
 }
 
 // NewManager creates a new model manager
-func NewManager(kuadrantClient dynamic.Interface) *Manager {
+func NewManager(k8sClient dynamic.Interface) *Manager {
 	return &Manager{
-		kuadrantClient: kuadrantClient,
+		k8sClient: k8sClient,
 	}
 }
 
@@ -34,7 +34,7 @@ func (m *Manager) ListAvailableModels() ([]ModelInfo, error) {
 	log.Printf("DEBUG: Attempting to list InferenceServices with GVR: %+v", inferenceServiceGVR)
 
 	// List all InferenceServices across all namespaces
-	list, err := m.kuadrantClient.Resource(inferenceServiceGVR).List(
+	list, err := m.k8sClient.Resource(inferenceServiceGVR).List(
 		context.Background(), metav1.ListOptions{})
 	if err != nil {
 		log.Printf("DEBUG: Failed to list InferenceServices: %v", err)


### PR DESCRIPTION
As the client is general-purpose k8s/client-go interface naming it `kuadrantClient` can be confusing.

This PR renames it to `k8sClient` across the key-manager codebase for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized internal Kubernetes client usage and naming across model and policy management components, aligning constructors and references for consistency. No changes to behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->