### PR TITLE
feat(config): enables seamless local/cluster config switching

### DIFF
--- a/key-manager/go.mod
+++ b/key-manager/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
@@ -41,6 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect

--- a/key-manager/go.sum
+++ b/key-manager/go.sum
@@ -55,6 +55,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
+github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/key-manager/internal/config/cluster_config.go
+++ b/key-manager/internal/config/cluster_config.go
@@ -31,8 +31,6 @@ func NewClusterConfig() (*K8sClusterConfig, error) {
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
-	// ... remainder of function unchanged ...
-}
 	return &K8sClusterConfig{
 		RestConfig: restConfig,
 		ClientSet:  clientset,

--- a/key-manager/internal/config/cluster_config.go
+++ b/key-manager/internal/config/cluster_config.go
@@ -18,19 +18,21 @@ type K8sClusterConfig struct {
 func NewClusterConfig() (*K8sClusterConfig, error) {
 	restConfig, err := LoadRestConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes config: %v", err)
+		return nil, fmt.Errorf("failed to create kubernetes config: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes ClientSet: %v", err)
+		return nil, fmt.Errorf("failed to create Kubernetes ClientSet: %w", err)
 	}
 
 	k8sClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
+	// ... remainder of function unchanged ...
+}
 	return &K8sClusterConfig{
 		RestConfig: restConfig,
 		ClientSet:  clientset,

--- a/key-manager/internal/config/cluster_config.go
+++ b/key-manager/internal/config/cluster_config.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type K8sClusterConfig struct {
+	RestConfig *rest.Config
+	ClientSet  *kubernetes.Clientset
+	DynClient  *dynamic.DynamicClient
+}
+
+func NewClusterConfig() (*K8sClusterConfig, error) {
+	restConfig, err := LoadRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes config: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes ClientSet: %v", err)
+	}
+
+	k8sClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
+	return &K8sClusterConfig{
+		RestConfig: restConfig,
+		ClientSet:  clientset,
+		DynClient:  k8sClient,
+	}, nil
+}
+
+// LoadRestConfig creates a *rest.Config using client-go loading rules.
+// Order:
+// 1) KUBECONFIG or $HOME/.kube/config (if present and non-default)
+// 2) If kubeconfig is empty/default (or IsEmptyConfig), fall back to in-cluster
+// Note: if kubeconfig is set but invalid (non-empty error), the error is returned.
+func LoadRestConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	config, kubeconfigErr := kubeConfig.ClientConfig()
+	if kubeconfigErr != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", kubeconfigErr)
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
Extracts k8s client creation to its own struct and enables lookup for local kube-config and in-cluster if that's not set.

This enables inner-loop development without requiring actual cluster deployment (assuming sufficient RBAC).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Health endpoint is always available without authentication for readiness/liveness checks.
  - Kubernetes configuration now auto-detects local kubeconfig or in-cluster settings for smoother setup.

- Refactor
  - Centralized cluster configuration centralizes client provisioning and simplifies manager/handler wiring.
  - Removed implicit default team creation; teams must be created explicitly.
  - Streamlined router initialization for cleaner request handling.

- Chores
  - Added indirect dependencies to support configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->