### PR TITLE
Leverage K8's Garbage Collector to handle cascading deletes

### DIFF
--- a/key-manager/internal/keys/manager.go
+++ b/key-manager/internal/keys/manager.go
@@ -315,6 +315,14 @@ func (m *Manager) createKeySecret(teamID string, req *CreateTeamKeyRequest, apiK
 	// Build models allowed list
 	modelsAllowed := strings.Join(req.Models, ",")
 
+    // Load owning team-config Secret so that it can own associated secrets.
+	// This allows them to be cleaned up by the GC when a team is deleted.
+    teamSecret, err := m.clientset.CoreV1().Secrets(m.keyNamespace).Get(
+        context.Background(), fmt.Sprintf("team-%s-config", teamID), metav1.GetOptions{})
+    if err != nil {
+        return nil, fmt.Errorf("team config not found: %w", err)
+    }
+
 	// Create enhanced secret with full team context
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -343,7 +351,14 @@ func (m *Manager) createKeySecret(teamID string, req *CreateTeamKeyRequest, apiK
 				"maas/created-at":            time.Now().Format(time.RFC3339),
 				"maas/status":                "active",
 			},
+            OwnerReferences: []metav1.OwnerReference{{
+                APIVersion: "v1",
+                Kind:       "Secret",
+                Name:       teamSecret.Name,
+                UID:        teamSecret.UID,
+            }},
 		},
+
 		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{
 			"api_key": apiKey,

--- a/key-manager/internal/teams/manager.go
+++ b/key-manager/internal/teams/manager.go
@@ -272,15 +272,11 @@ func (m *Manager) Delete(teamID string) error {
 		}
 	}
 
-	// Delete all team API keys
-	err = m.deleteAllTeamKeys(teamID)
-	if err != nil {
-		log.Printf("Failed to delete team keys: %v", err)
-	}
+    // Foreground delete: GC removes owned key Secrets first, then the team
+    fg := metav1.DeletePropagationForeground
+    err = m.clientset.CoreV1().Secrets(m.keyNamespace).Delete(
+        context.Background(), teamSecret.Name, metav1.DeleteOptions{PropagationPolicy: &fg})
 
-	// Delete team configuration secret
-	err = m.clientset.CoreV1().Secrets(m.keyNamespace).Delete(
-		context.Background(), teamSecret.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete team: %w", err)
 	}


### PR DESCRIPTION
API keys are owned by teams, so when teams are deleted the keys are cleaned up for free.


## How Has This Been Tested?
https://gist.github.com/usize/30e4359d1a62b8dd975212eda6f3ef0e

## Merge criteria:

- [ x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x] The developer has manually tested the changes and verified that the changes work
