### PR TITLE
Add example for `/v1/models` to the test workflow

### DIFF
--- a/key-manager/README.md
+++ b/key-manager/README.md
@@ -112,6 +112,8 @@ curl -s http://$QWEN3_ROUTE/v1/chat/completions \
 
 TODO: Enable user-scoped model access listing
 
+For `InferenceServices`, use the `/models` endpoint:
+
 ```bash
 curl -sk -X GET https://$KEY_MANAGER_ROUTE/models \
   -H "Authorization: ADMIN $ADMIN_KEY" | jq .
@@ -135,6 +137,30 @@ curl -sk -X GET https://$KEY_MANAGER_ROUTE/models \
       "ready": true
     }
   ]
+}
+```
+
+For `LLMInferenceServices`, use the `/v1/models` endpoint:
+
+```bash
+curl -sk -X GET https://$KEY_MANAGER_ROUTE/v1/models \
+  -H "Authorization: ADMIN $ADMIN_KEY" | jq .
+```
+
+- Example Output
+
+
+```
+{
+  "data": [
+    {
+      "id": "qwen3-0-6b-instruct",
+      "created": 1756849635,
+      "object": "model",
+      "owned_by": "llm"
+    }
+  ],
+  "object": "list"
 }
 ```
 


### PR DESCRIPTION
Add example for `/v1/models` to the test workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded “List Available Models” workflow with two sections: InferenceServices (/models) and LLMInferenceServices (/v1/models).
  * Added curl examples and sample responses showing model fields and overall response structure.
  * Noted that both endpoints require ADMIN authorization.
  * Included explicit Example Output blocks for quick reference.
  * Placed updates after the existing placeholder; no behavior, API, or code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->