### PR TITLE
Fix the namespace in the maas-api quickstart

### DIFF
--- a/maas-api/README.md
+++ b/maas-api/README.md
@@ -19,7 +19,7 @@ export TEAM_ID="test-team"
 export USER_ID="test-user"
 
 # Dynamically detect routes instead of hardcoding them
-export MAAS_API_ROUTE=$(oc get routes maas-api-route -n llm | tail -1 | awk '{print $2}')
+export MAAS_API_ROUTE=$(oc get routes maas-api-route -n platform-services | tail -1 | awk '{print $2}')
 export QWEN3_ROUTE=$(oc get routes qwen3-route -n llm | tail -1 | awk '{print $2}')
 export SIMULATOR_ROUTE=$(oc get routes simulator-route -n llm | tail -1 | awk '{print $2}')
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected automatic detection of the MAAS API route to target the appropriate namespace, preventing misrouting and connection failures in certain environments.
  - Improves startup reliability and reduces configuration errors when initializing the MAAS API connection.
  - Other service route detections remain unchanged, with no impact on their behavior.
  - No user action required; the application will use the correct route automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->