### PR TITLE
chore: swaps to quay.io image

### DIFF
--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -7,7 +7,7 @@ ifeq (podman,$(CONTAINER_ENGINE))
 endif
 
 # Image settings
-REPO ?= ghcr.io/your-org/maas-api
+REPO ?= quay.io/opendatahub/maas-api
 TAG ?= latest
 FULL_IMAGE ?= $(REPO):$(TAG)
 

--- a/maas-api/deploy/base/params.env
+++ b/maas-api/deploy/base/params.env
@@ -1,2 +1,2 @@
 # Image configuration
-maas-api-image=ghcr.io/redhat-et/maas-key-manager:latest
+maas-api-image=quay.io/opendatahub/maas-api:latest

--- a/maas-api/deploy/overlays/dev/kustomization.yaml
+++ b/maas-api/deploy/overlays/dev/kustomization.yaml
@@ -19,10 +19,10 @@ patches:
 - path: patches/debug-mode-patch.yaml
 
 # Overwrite the image to use the local image set through kustomize edit set image
-# This is needed because the image is set to ghcr.io/redhat-et/maas-key-manager in the base/deployment.yaml using params.env "injection"
+# This is needed because the image is set in the base/deployment.yaml using params.env "injection"
 images:
-- name: ghcr.io/redhat-et/maas-key-manager
-  newName: maas-api
+- name: maas-api
+  newName: quay.io/opendatahub/maas-api:latest
   newTag: latest
 
 secretGenerator:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Switched the default container image source to quay.io/opendatahub/maas-api.
  - Updated deployment parameters and development overlay to reference the new image registry and tag.
- Documentation
  - Clarified comments explaining how the deployment image is injected via params.

No user-facing behavior changes; deployments now pull the image from the new registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->