### PR TITLE
fix: TokenRateLimitPolicy targets right gateway

### DIFF
--- a/deployment/base/policies/token-limit-policy.yaml
+++ b/deployment/base/policies/token-limit-policy.yaml
@@ -11,7 +11,7 @@ spec:
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway
-    name: inference-gateway
+    name: openshift-ai-inference
   limits:
     free-user-tokens:
       rates:


### PR DESCRIPTION
Fix for #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated rate-limiting configuration to point to the current inference gateway.
  - No changes to rate limits, predicates, counters, or control flow.
  - Error handling and monitoring remain unchanged.
  - No user-facing impact expected; behavior and performance should be identical.
  - Applies automatically after deployment with no action required.
  - Compatibility with existing clients preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->