### PR TITLE
chore: create workflow for common commits

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,64 @@
+name: PR Title Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Validate PR Title Format
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure the allowed types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Allow breaking changes
+          requireScope: false
+          # Allow empty scope
+          allowMergeCommits: true
+          # Disable validation for draft PRs
+          ignoreLabels: |
+            draft
+            wip
+          # Configure the subject pattern
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern. Please ensure that the subject doesn't start with a capital letter.
+          # Configure the subject pattern error
+          validateSingleCommit: false
+          # Configure the body pattern (optional)
+          bodyPattern: ^.*$
+          bodyPatternError: |
+            The pull request body didn't match the configured pattern.
+          # Configure the body pattern error
+          ignoreLabelsForTitle: |
+            draft
+            wip
+          # Configure the body pattern error
+          ignoreLabelsForBody: |
+            draft
+            wip


### PR DESCRIPTION
Creating PR to insure we are using Common Commits Format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced an automated PR title validation workflow for pull requests.
  - Validates titles against conventional commit types and format.
  - Runs on PR open, edit, and synchronize events with a short timeout.
  - Provides actionable feedback on non-compliant titles.
  - Skips validation when PRs are labeled as draft or WIP.
  - No changes to the product experience or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->