### PR TITLE
feat: dedicated MaaS gateway

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -134,7 +134,7 @@ kubectl -n kuadrant-system patch deployment kuadrant-operator-controller-manager
 Wait for Gateway to be ready:
 
 ```bash
-kubectl wait --for=condition=Programmed gateway openshift-ai-inference -n openshift-ingress --timeout=300s
+kubectl wait --for=condition=Programmed gateway maas-default-gateway -n openshift-ingress --timeout=300s
 ```
 
 Then restart Kuadrant operators:
@@ -157,17 +157,6 @@ kubectl patch csv kuadrant-operator.v0.0.0 -n kuadrant-system --type='json' -p='
     }
   }
 ]'
-```
-
-#### Update KServe Ingress Domain
-```bash
-kubectl -n kserve patch configmap inferenceservice-config \
-  --type='json' \
-  -p="[{
-    \"op\": \"replace\",
-    \"path\": \"/data/ingress\",
-    \"value\": \"{\\\"enableGatewayApi\\\": true, \\\"kserveIngressGateway\\\": \\\"openshift-ingress/openshift-ai-inference\\\", \\\"ingressGateway\\\": \\\"istio-system/istio-ingressgateway\\\", \\\"ingressDomain\\\": \\\"$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')\\\"}\"
-  }]"
 ```
 
 #### Update Limitador Image for Metrics (Optional but Recommended)
@@ -206,12 +195,12 @@ kubectl patch authpolicy maas-api-auth-policy -n maas-api \
 
 For OpenShift:
 ```bash
-HOST="$(kubectl get gateway openshift-ai-inference -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
+HOST="$(kubectl get gateway maas-default-gateway -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
 ```
 
 For Kubernetes with LoadBalancer:
 ```bash
-HOST="$(kubectl get gateway openshift-ai-inference -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
+HOST="$(kubectl get gateway maas-default-gateway -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
 ```
 
 ### 2. Get Authentication Token
@@ -276,7 +265,7 @@ kubectl get pods -n llm
 Check Gateway status:
 
 ```bash
-kubectl get gateway -n openshift-ingress openshift-ai-inference
+kubectl get gateway -n openshift-ingress maas-default-gateway
 ```
 
 Check that policies are enforced:

--- a/deployment/base/maas-api/networking/httproute.yaml
+++ b/deployment/base/maas-api/networking/httproute.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: maas-api
 spec:
   parentRefs:
-    - name: openshift-ai-inference
+    - name: maas-default-gateway
       namespace: openshift-ingress
   rules:
     - matches:

--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -16,4 +16,4 @@ spec:
         kubernetesTokenReview:
           audiences:
             - https://kubernetes.default.svc
-            - openshift-ai-inference-sa
+            - maas-default-gateway-sa

--- a/deployment/base/networking/gateway-api.yaml
+++ b/deployment/base/networking/gateway-api.yaml
@@ -6,11 +6,32 @@ metadata:
 spec:
   controllerName: "openshift.io/gateway-controller/v1"
 ---
+# Default LLMInferenceService Gateway
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: openshift-ai-inference
   namespace: openshift-ingress
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+   - name: http
+     port: 80
+     protocol: HTTP
+     allowedRoutes:
+       namespaces:
+         from: All
+---
+# Default MaaS Gateway for LLMInferenceServices - opt-in to MaaS features
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: maas-default-gateway
+    app.kubernetes.io/component: gateway
 spec:
   gatewayClassName: openshift-default
   listeners:

--- a/deployment/base/policies/gateway-auth-policy.yaml
+++ b/deployment/base/policies/gateway-auth-policy.yaml
@@ -8,7 +8,7 @@ spec:
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway
-    name: openshift-ai-inference
+    name: maas-default-gateway
   rules:
     metadata:
       # Enriching identity metadata with a proper subscription tier based on user groups
@@ -29,7 +29,7 @@ spec:
       service-accounts:
         kubernetesTokenReview:
           audiences:
-            - openshift-ai-inference-sa
+            - maas-default-gateway-sa
         defaults:
           # token normalization - https://docs.kuadrant.io/1.2.x/authorino/docs/user-guides/token-normalization/
           # full username: system:serviceaccount:<ns>:<name>

--- a/deployment/base/policies/rate-limit-policy.yaml
+++ b/deployment/base/policies/rate-limit-policy.yaml
@@ -7,7 +7,7 @@ spec:
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway
-    name: openshift-ai-inference
+    name: maas-default-gateway
   limits:
     free:
       rates:

--- a/deployment/base/policies/token-limit-policy.yaml
+++ b/deployment/base/policies/token-limit-policy.yaml
@@ -11,7 +11,7 @@ spec:
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway
-    name: openshift-ai-inference
+    name: maas-default-gateway
   limits:
     free-user-tokens:
       rates:

--- a/deployment/components/odh/kserve/kustomization.yaml
+++ b/deployment/components/odh/kserve/kustomization.yaml
@@ -8,6 +8,6 @@ metadata:
 # For now, install only Model Serving pieces
 resources:
 - github.com/opendatahub-io/kserve/config/overlays/odh?ref=release-v0.15
-  
+
 namespace: opendatahub
 

--- a/deployment/overlays/openshift/gateway-route.yaml
+++ b/deployment/overlays/openshift/gateway-route.yaml
@@ -13,8 +13,8 @@ metadata:
   name: gateway-route
   namespace: openshift-ingress
   labels:
-    app: openshift-ai-inference
-    gateway: openshift-ai-inference
+    app: maas
+    gateway: maas-default-gateway
 spec:
   host: gateway.apps.test-maas-v1.eh5f.s1.devshift.org
   port:
@@ -24,6 +24,6 @@ spec:
     termination: edge
   to:
     kind: Service
-    name: openshift-ai-inference-openshift-default
+    name: maas-default-gateway-openshift-default
     weight: 100
   wildcardPolicy: None 

--- a/deployment/scripts/deploy-openshift.sh
+++ b/deployment/scripts/deploy-openshift.sh
@@ -257,13 +257,6 @@ else
   echo "   ✅ Kuadrant operator already configured"
 fi
 
-# Update KServe Ingress Domain
-echo "   Updating KServe configuration..."
-kubectl -n kserve patch configmap inferenceservice-config \
-  --type='json' \
-  -p="[{\"op\": \"replace\", \"path\": \"/data/ingress\", \"value\": \"{\\\"enableGatewayApi\\\": true, \\\"kserveIngressGateway\\\": \\\"openshift-ingress/openshift-ai-inference\\\", \\\"ingressGateway\\\": \\\"istio-system/istio-ingressgateway\\\", \\\"ingressDomain\\\": \\\"$CLUSTER_DOMAIN\\\"}\" }]" 2>/dev/null || \
-  echo "   KServe already configured"
-
 echo ""
 echo "8️⃣ Waiting for Gateway to be ready..."
 echo "   Note: This may take a few minutes if Service Mesh is being automatically installed..."
@@ -282,7 +275,7 @@ else
 fi
 
 echo "   Waiting for Gateway to become ready..."
-kubectl wait --for=condition=Programmed gateway openshift-ai-inference -n openshift-ingress --timeout=300s || \
+kubectl wait --for=condition=Programmed gateway maas-default-gateway -n openshift-ingress --timeout=300s || \
   echo "   ⚠️  Gateway is taking longer than expected, continuing..."
 
 echo ""
@@ -343,8 +336,8 @@ kubectl get pods -n opendatahub --no-headers | grep Running | wc -l | xargs echo
 
 echo ""
 echo "Gateway Status:"
-kubectl get gateway -n openshift-ingress openshift-ai-inference -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' | xargs echo "  Accepted:"
-kubectl get gateway -n openshift-ingress openshift-ai-inference -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' | xargs echo "  Programmed:"
+kubectl get gateway -n openshift-ingress maas-default-gateway -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' | xargs echo "  Accepted:"
+kubectl get gateway -n openshift-ingress maas-default-gateway -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' | xargs echo "  Programmed:"
 
 echo ""
 echo "Policy Status:"

--- a/docs/gateway-setup.md
+++ b/docs/gateway-setup.md
@@ -1,0 +1,252 @@
+# MaaS Gateway Setup Guide
+
+This guide explains how to set up a dedicated Gateway for Model-as-a-Service (MaaS) with authentication, rate limiting, and token-based consumption tracking.
+
+## Overview
+
+The MaaS platform follows a **segregated gateway approach**, where models explicitly opt-in to MaaS capabilities. 
+This approach provides flexibility and isolation between different model deployment scenarios and existing ODH Models already used by customers.
+
+### Gateway Architecture
+
+```mermaid
+graph TB
+    subgraph cluster["OpenShift/Kubernetes Cluster"]
+        subgraph gateways["Gateway Layer"]
+            defaultGW["<b>Default Gateway</b><br/>(ODH/KServe)<br/><br/>✓ Existing auth model<br/>✓ No rate limits<br/>"]
+            maasGW["<b>MaaS Gateway</b><br/>(maas-default-gateway)<br/><br/>✓ Token authentication<br/>✓ Tier-based rate limits<br/>✓ Token consumption "]
+        end
+
+        subgraph models["Model Deployments"]
+            standardModel["LLMInferenceService<br/>(Standard)<br/><br/>spec:<br/>  model: ...<br/>  # Managed default Gateway instance"]
+            maasModel["LLMInferenceService<br/>(MaaS-enabled)<br/><br/>spec:<br/>  model: ...<br/>  gateway:<br/>    refs:<br/>      - name: maas-default-gateway"]
+        end
+
+        defaultGW -.->|"Routes to"| standardModel
+        maasGW ==>|"Routes to"| maasModel
+    end
+
+    users["Users/Clients"] -->|"Default ODH auth"| defaultGW
+    apiUsers["API Clients"] -->|"Bearer token"| maasGW
+
+    style defaultGW fill:#e1f5ff
+    style maasGW fill:#fff4e6
+    style standardModel fill:#f5f5f5
+    style maasModel fill:#fff9e6
+    style cluster fill:#fafafa
+    style gateways fill:#ffffff
+    style models fill:#ffffff
+```
+
+## Why Gateway Segregation?
+
+### Benefits
+
+1. **Flexibility**: Different models can have different security and access requirements
+2. **Progressive Adoption**: Teams can adopt MaaS features incrementally
+3. **Development Freedom**: Dev/test models don't need authentication overhead
+4. **Production Control**: Production models get full policy enforcement if needed
+5. **Multi-Tenancy**: Different teams can use different gateways in the same cluster
+6. **Blast Radius Containment**: Issues with one gateway don't affect the other
+
+## Prerequisites
+
+Before setting up the MaaS gateway, ensure you have:
+
+- **OpenShift 4.19.9+**
+- **Red Hat Connectivity Link/Red Hat Connectivity Link** installed (provides AuthPolicy, RateLimitPolicy, TokenRateLimitPolicy CRDs)
+- **Cluster admin** or equivalent permissions
+- **MaaS API** deployed (for tier lookup functionality)
+
+> [!NOTE] 
+> For complete deployment prerequisites and platform-specific requirements, see the [Deployment Guide](../deployment/README.md).
+
+## Step 1: Create GatewayClass
+
+The GatewayClass defines which controller will manage the Gateway. On OpenShift, use the built-in gateway controller:
+
+> [!NOTE] 
+> On OpenShift 4.19.9+, the GatewayClass is automatically available. On earlier versions, you may need to enable Gateway API feature gates first.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: "openshift.io/gateway-controller/v1"
+EOF
+```
+
+## Step 2: Create the MaaS Gateway
+
+Create a dedicated Gateway for MaaS-enabled models. Key configuration points:
+
+- **Name**: `maas-default-gateway` - This is what models will reference
+- **Namespace**: `openshift-ingress` - Standard namespace for gateway infrastructure in Openshift
+- **Labels**: Help identify the gateway and enable label-based queries
+- **allowedRoutes.from: All** - Allows HTTPRoutes from any namespace to attach to this gateway
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: maas-default-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+```
+
+**Verify the Gateway is ready:**
+
+```shell
+kubectl get gateway maas-default-gateway -n openshift-ingress
+kubectl wait --for=condition=Programmed gateway maas-default-gateway -n openshift-ingress --timeout=300s
+```
+
+Expected output:
+```text
+NAME                   CLASS               ADDRESS        PROGRAMMED   AGE
+maas-default-gateway   openshift-default   10.0.1.100     True         2m
+```
+
+## Step 3: Apply Gateway Policies
+
+The MaaS gateway uses Red Hat Connectivity Link policies to enforce authentication, authorization, and rate limiting. Apply the following policies to enable MaaS capabilities:
+
+### AuthPolicy - Authentication & Authorization
+
+The AuthPolicy validates tokens, determines user tiers, and enforces access control:
+
+```bash
+kubectl apply -f deployment/base/policies/gateway-auth-policy.yaml
+```
+
+**What it does:**
+- **Token Validation**: Verifies Kubernetes service account tokens with the correct audience (`maas-default-gateway-sa`)
+- **Tier Lookup**: Queries the MaaS API to determine user's subscription tier based on their group membership
+- **Access Control**: Uses Kubernetes RBAC to verify users have permission to access specific models
+- **Identity Enrichment**: Injects user ID and tier information into requests for downstream policies
+
+> [!NOTE]
+> User tiers are determined by namespace membership. Service accounts in `maas-default-gateway-tier-{free|premium|enterprise}` namespaces automatically inherit the corresponding tier. See [Tiers Documentation](./tiers.md) for complete tier management details.
+
+### RateLimitPolicy - Request Rate Limiting
+
+The RateLimitPolicy limits the number of requests per user based on their tier:
+
+```bash
+kubectl apply -f deployment/base/policies/rate-limit-policy.yaml
+```
+
+**Default limits:**
+- **Free tier**: 5 requests per 2 minutes
+- **Premium tier**: 20 requests per 2 minutes
+- **Enterprise tier**: 50 requests per 2 minutes
+
+These limits prevent abuse and ensure fair resource allocation across users. See [Tiers Documentation](./tiers.md) for information on customizing tier limits.
+
+### TokenRateLimitPolicy - Token Consumption Limiting
+
+The TokenRateLimitPolicy tracks and limits the total number of LLM tokens consumed:
+
+```bash
+kubectl apply -f deployment/base/policies/token-limit-policy.yaml
+```
+
+**Default limits:**
+- **Free tier**: 100 tokens per minute
+- **Premium tier**: 50,000 tokens per minute
+- **Enterprise tier**: 100,000 tokens per minute
+
+This policy automatically extracts token usage from model responses (`usage.total_tokens` field) and enforces consumption limits. See [Tiers Documentation](./tiers.md) for tier-based billing and quota management.
+
+### Verify Policy Status
+
+After applying policies, verify they are accepted by the gateway:
+
+```bash
+kubectl get authpolicy gateway-auth-policy -n openshift-ingress
+kubectl get ratelimitpolicy gateway-rate-limits -n openshift-ingress
+kubectl get tokenratelimitpolicy gateway-token-rate-limits -n openshift-ingress
+```
+
+All policies should show `Accepted: True` in their status conditions.
+
+## Step 4: Configure Models to Use MaaS Gateway
+
+Models opt-in to MaaS by specifying the gateway in their LLMInferenceService spec:
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: my-production-model
+  namespace: llm
+spec:
+  model:
+    uri: hf://Qwen/Qwen3-0.6B
+    name: Qwen/Qwen3-0.6B
+  replicas: 1
+  
+  # Opt-in to MaaS Gateway
+  gateway:
+    refs:
+      - name: maas-default-gateway
+        namespace: openshift-ingress
+  
+  # Router configuration (separate from gateway)
+  router:
+    route: { }
+  
+  template:
+    # ... container configuration ...
+```
+
+**Without this gateway specification**, the model uses the default KServe gateway and **is not subject to MaaS policies**.
+
+## Verification
+
+Once you've completed the gateway setup, verify that everything is working correctly:
+
+```bash
+kubectl get gateway maas-default-gateway -n openshift-ingress
+```
+
+See the [Deployment Guide Testing section](../deployment/README.md#testing-the-deployment) and [Developer Guide](../maas-api/DEV.md#testing).
+
+## References
+
+### Gateway and Kubernetes
+
+- [Gateway API Documentation](https://gateway-api.sigs.k8s.io/)
+- [KServe LLMInferenceService](https://kserve.github.io/website/)
+
+### Red Hat Connectivity Link Policies
+
+- [Red Hat Connectivity Link Documentation](https://docs.kuadrant.io/)
+- [AuthPolicy - Authentication & Authorization](https://docs.kuadrant.io/latest/kuadrant-operator/doc/auth/)
+- [RateLimitPolicy - Request Rate Limiting](https://docs.kuadrant.io/latest/kuadrant-operator/doc/rate-limiting/)
+- [Authorino - Authentication Service](https://docs.kuadrant.io/latest/authorino/)
+- [Limitador - Rate Limiting Service](https://docs.kuadrant.io/latest/limitador/)
+
+### MaaS Platform
+
+- [Tiers Management](./tiers.md)
+- [Deployment Guide](../deployment/README.md)
+
+

--- a/docs/samples/models/facebook-opt-125m-cpu/model.yaml
+++ b/docs/samples/models/facebook-opt-125m-cpu/model.yaml
@@ -9,6 +9,11 @@ spec:
   replicas: 1
   router:
     route: { }
+    # Connect to MaaS-enabled gateway
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
   template:
     containers:
       - name: main

--- a/docs/samples/models/qwen3/model.yaml
+++ b/docs/samples/models/qwen3/model.yaml
@@ -10,6 +10,11 @@ spec:
   replicas: 1
   router:
     route: { }
+    # Connect to MaaS-enabled gateway
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
   template:
     nodeSelector:
       nvidia.com/gpu.present: "true"

--- a/docs/samples/models/rbac/all-tiers.yaml
+++ b/docs/samples/models/rbac/all-tiers.yaml
@@ -14,13 +14,13 @@ metadata:
   name: model-user-tier-binding
 subjects:
   - kind: Group
-    name: system:serviceaccounts:openshift-ai-inference-tier-free
+    name: system:serviceaccounts:maas-default-gateway-tier-free
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
-    name: system:serviceaccounts:openshift-ai-inference-tier-premium
+    name: system:serviceaccounts:maas-default-gateway-tier-premium
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
-    name: system:serviceaccounts:openshift-ai-inference-tier-enterprise
+    name: system:serviceaccounts:maas-default-gateway-tier-enterprise
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -9,6 +9,11 @@ spec:
   replicas: 1
   router:
     route: { }
+    # Connect to MaaS-enabled gateway
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
   template:
     containers:
       - name: main

--- a/maas-api/DEV.md
+++ b/maas-api/DEV.md
@@ -138,7 +138,7 @@ kustomize build ${PROJECT_DIR}/docs/samples/models/simulator | kubectl apply --s
 To see the token, you can use the following commands:
 
 ```shell
-HOST="$(kubectl get gateway openshift-ai-inference -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
+HOST="$(kubectl get gateway -l app.kubernetes.io/instance=maas-default-gateway -n openshift-ingress -o jsonpath='{.items[0].status.addresses[0].value}')"
 
 TOKEN_RESPONSE=$(curl -sSk \
   -H "Authorization: Bearer $(oc whoami -t)" \
@@ -163,7 +163,7 @@ TOKEN=$(echo $TOKEN_RESPONSE | jq -r .token)
 Using model discovery:
 
 ```shell
-HOST="$(kubectl get gateway openshift-ai-inference -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
+HOST="$(kubectl get gateway -l app.kubernetes.io/instance=maas-default-gateway -n openshift-ingress -o jsonpath='{.items[0].status.addresses[0].value}')"
 
 MODELS=$(curl ${HOST}/maas-api/v1/models  \
     -H "Content-Type: application/json" \

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -3,5 +3,5 @@ package constant
 const (
 	TierMappingConfigMap = "tier-to-group-mapping"
 	DefaultNamespace     = "maas-api"
-	DefaultGatewayName   = "openshift-ai-inference"
+	DefaultGatewayName   = "maas-default-gateway"
 )

--- a/scripts/verify-models-and-limits.sh
+++ b/scripts/verify-models-and-limits.sh
@@ -23,7 +23,7 @@ if [ -z "${GATEWAY_URL:-}" ]; then
     
     # Fallback to gateway status address if route not available
     if [ -z "${GATEWAY_URL:-}" ]; then
-        HOST=$(kubectl get gateway openshift-ai-inference -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')
+        HOST=$(kubectl get gateway maas-default-gateway -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')
         if [ -z "$HOST" ]; then
             echo "Failed to resolve gateway host; set GATEWAY_URL explicitly." >&2
             exit 1


### PR DESCRIPTION
This PR updates manifests (and sample models) to use a dedicated MaaS gateway instead of the default one used by KServe/LLMInferenceService.

The segregated gateway approach ensures flexibility and isolation:
- Existing ODH/KServe models remain unaffected
- Models explicitly opt-in to MaaS features when ready
- Traffic, resources, and policies are isolated for safer operations

## Testing

Deploy using

```shell
./deployment/scripts/deploy-openshift.sh
```

Update the image:  

```
 kubectl -n maas-api patch deployment maas-api \
  --type='strategic' \
  -p='{"spec":{"template":{"spec":{"containers":[{"name":"maas-api","image":"quay.io/bmajsak/maas-api:maas-default-gateway"}]}}}}'
```

and validate:

```shell
./scripts/verify-models-and-limits.sh
```

#### Updating existing deployment

- Use `./deployment/scripts/deploy-openshift.sh` or apply relevant kustomize manifests
- *Do not change* Kserve configuration - default gateway should remain as `openshift-ai-inference`
- Re-apply manifests for sample models to attach them to MaaS gateway

You can also remove old "tier namespaces", as they are not used anymore:

```shell
kubectl delete ns openshift-ai-inference-tier-free
kubectl delete ns openshift-ai-inference-tier-premium  
kubectl delete ns openshift-ai-inference-tier-enterprise
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a dedicated MaaS default gateway with authentication and rate-limiting policies; OpenShift route aligned; sample models updated to route via the new gateway.
* Documentation
  * Added a MaaS Gateway Setup Guide; updated deployment and dev docs, samples, and RBAC to reflect the new gateway and verification steps.
* Chores
  * Replaced legacy gateway references across manifests and scripts; removed obsolete ingress-domain updates; improved gateway readiness/status checks.
* Style
  * Minor formatting cleanup in a kustomization file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->