### PR TITLE
chore: Remove unneeded ca-certificates package from Dockerfile

### DIFF
--- a/maas-api/Dockerfile
+++ b/maas-api/Dockerfile
@@ -13,9 +13,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./c
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-# Install CA certificates for HTTPS requests
-RUN microdnf install -y ca-certificates && microdnf clean all
-
 WORKDIR /app
 
 COPY --from=builder /app/maas-api .


### PR DESCRIPTION
The core functionalities of the maas-api (listing models, creating tokens, supporting authN/authZ) are working properly without the `ca-certificates` package. Thus, removing this package.

The main motivation for the removal is compatibility with hermetic Konflux builds which were failing because of the presence of this package. Secondarily, it is always better to not install unneeded packages keeping the image small, and reducing attack surface (if any).

Related to https://issues.redhat.com/browse/RHOAIENG-33988

## How Has This Been Tested?

Manual testing of the main functionalities of `maas-api`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the runtime container image by removing bundled CA certificates, reducing image size.
* **Potential Impact**
  * HTTPS requests now rely on the base image’s default certificate store; environments that require custom or enterprise CAs may need additional configuration.
  * If outbound HTTPS validation fails in certain environments, ensure required CA certificates are provided via base image, runtime injection, or configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->