### PR TITLE
[doc] remove JWT dependency

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -173,10 +173,7 @@ kubectl -n kuadrant-system patch limitador limitador --type merge \
 Patch `AuthPolicy` with the correct audience for Openshift Identities:
 
 ```shell
-PROJECT_DIR=$(git rev-parse --show-toplevel)
-AUD="$(kubectl create token default --duration=10m \
-  | jwt decode --json - \
-  | jq -r '.payload.aud[0]')"
+AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.aud[0]' 2>/dev/null)"
 
 echo "Patching AuthPolicy with audience: $AUD"
 
@@ -187,7 +184,7 @@ kubectl patch authpolicy maas-api-auth-policy -n maas-api \
     path:"/spec/rules/authentication/openshift-identities/kubernetesTokenReview/audiences/0",
     value:$aud
   }]')"
-  
+
 ```
 ## Testing the Deployment
 


### PR DESCRIPTION
- Remove the JWT dependency in favor of the command used in the installer to avoid JWT version/flavor mismatching. Also one less required tool for the user.

Example usage and output of the patch:

```
$ AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.aud[0]' 2>/dev/null)"

echo "Patching AuthPolicy with audience: $AUD"

kubectl patch authpolicy maas-api-auth-policy -n maas-api \
  --type='json' \
  -p "$(jq -nc --arg aud "$AUD" '[{
    op:"replace",
    path:"/spec/rules/authentication/openshift-identities/kubernetesTokenReview/audiences/0",
    value:$aud
  }]')"
Patching AuthPolicy with audience: https://kubernetes.default.svc
authpolicy.kuadrant.io/maas-api-auth-policy patched
```


Error I ran into when using `jwt`:

```
PROJECT_DIR=$(git rev-parse --show-toplevel)
AUD="$(kubectl create token default --duration=10m \
  | jwt decode --json - \
  | jq -r '.payload.aud[0]')"

echo "Patching AuthPolicy with audience: $AUD"

kubectl patch authpolicy maas-api-auth-policy -n maas-api \
  --type='json' \
  -p "$(jq -nc --arg aud "$AUD" '[{
    op:"replace",
    path:"/spec/rules/authentication/openshift-identities/kubernetesTokenReview/audiences/0",
    value:$aud
  }]')"

Usage of jwt:
  One of the following flags is required: sign, verify or show
  -alg string
    	signing algorithm identifier, one of
    	ES256, ES384, ES512, EdDSA, HS256, HS384, HS512,
    	PS256, PS384, PS512, RS256, RS384, RS512, none
  -claim value
    	add additional claims. may be used more than once (default {})
  -compact
    	output compact JSON
  -debug
    	print out all kinds of debug data
  -header value
    	add additional header params. may be used more than once (default {})
  -key string
    	path to key file or '-' to read from stdin
  -show string
    	path to JWT token file to show without verification or '-' to read from stdin
  -sign string
    	path to claims file to sign, '-' to read from stdin, or '+' to use only -claim args
  -verify string
    	path to JWT token file to verify or '-' to read from stdin
Error: none of the required flags are present. What do you want me to do?
Patching AuthPolicy with audience:
authpolicy.kuadrant.io/maas-api-auth-policy patched (no change)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide to use a simplified method for extracting the audience from Kubernetes tokens.
  * Removed dependency on previous JWT-based approach, reducing setup friction.
  * Improved error handling and clarity of commands to minimize noisy output and confusion.
  * Refreshed examples and formatting to reflect the new approach and ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->